### PR TITLE
Add IsPlural() and IsSingular() public methods to the singleton pluralization provider.

### DIFF
--- a/PluralizeService.Core.Tests/Tests/IsPluralTests.cs
+++ b/PluralizeService.Core.Tests/Tests/IsPluralTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace PluralizeService.Core.Tests
+{
+    public class IsPluralTests
+    {
+        [Theory]
+        [InlineData("Email", false)]
+        [InlineData("Emails", true)]
+        [InlineData("company", false)]
+        [InlineData("companies", true)]
+        [InlineData("Crisis", false)]
+        [InlineData("Crises", true)]
+        [InlineData("Fungus", false)]
+        [InlineData("Fungi", true)]
+        [InlineData("bus", false)]
+        [InlineData("buses", true)]
+        public void WordIsPlural(string word, bool expected)
+        {
+            // Arrange
+            bool actual = PluralizationProvider.IsPlural(word);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/PluralizeService.Core.Tests/Tests/IsSingularTests.cs
+++ b/PluralizeService.Core.Tests/Tests/IsSingularTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace PluralizeService.Core.Tests
+{
+    public class IsSingularTests
+    {
+        [Theory]
+        [InlineData("Email", true)]
+        [InlineData("Emails", false)]
+        [InlineData("company", true)]
+        [InlineData("companies", false)]
+        [InlineData("Crisis", true)]
+        [InlineData("Crises", false)]
+        [InlineData("Fungus", true)]
+        [InlineData("Fungi", false)]
+        [InlineData("bus", true)]
+        [InlineData("buses", false)]
+        public void WordIsSingular(string word, bool expected)
+        {
+            // Arrange
+            bool actual = PluralizationProvider.IsSingular(word);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/PluralizeService.Core/PluralizationProvider.cs
+++ b/PluralizeService.Core/PluralizationProvider.cs
@@ -42,5 +42,21 @@ namespace PluralizeService.Core
         public static string Singularize(string word) =>
             pluralization.Singularize(word, culture) ?? word;
 
+        /// <summary>
+        /// Determines if the specified word is plural in the language associated with the current culture.
+        /// </summary>
+        /// <param name="word">The word to test.</param>
+        /// <returns>True if plural, otherwise false.</returns>
+        public static bool IsPlural(string word) =>
+            pluralization.IsPlural(word, culture);
+
+        /// <summary>
+        /// Determines if the specified word is singular in the language associated with the current culture.
+        /// </summary>
+        /// <param name="word">The word to test.</param>
+        /// <returns>True if singular, otherwise false.</returns>
+        public static bool IsSingular(string word) =>
+            pluralization.IsSingular(word, culture);
+
     }
 }


### PR DESCRIPTION
I was using this package as part of porting a project from Framework to Core, and found that these methods which were available in the old PluralizationService in.NET Framework were not publicly exposed on the `PluralizationProvider`. I think it's useful to have these available; if you have access to `Pluralize()` and `Singularize()`, it's good to be able to know which one you need to call.

So I've added the methods. Included some tests in keeping with the style.