### PR TITLE
Add 'euro' pluralisation

### DIFF
--- a/PluralizeService.Core.Tests/Tests/PluralizeTests.cs
+++ b/PluralizeService.Core.Tests/Tests/PluralizeTests.cs
@@ -10,6 +10,8 @@ namespace PluralizeService.Core.Tests
         [InlineData("Project", "Projects")]
         [InlineData("Container", "Containers")]
         [InlineData("bus", "buses")]
+        [InlineData("euro", "euros")]
+        [InlineData("Euro", "Euros")]
         public void ShouldPluralizeWord(string word, string expected)
         {
             // Arrange

--- a/PluralizeService.Core/English/Adapters/EnglishMetaDataAdapter.cs
+++ b/PluralizeService.Core/English/Adapters/EnglishMetaDataAdapter.cs
@@ -245,7 +245,8 @@ namespace PluralizationService.English.Adapters
             { "rhino", "rhinos" },
             { "fiasco", "fiascos" },
             { "magneto", "magnetos" },
-            { "stylo", "stylos" }
+            { "stylo", "stylos" },
+            { "euro", "euros" },
         };
 
         private Dictionary<string, string> _classicalInflectionDictionary = new Dictionary<string, string>()


### PR DESCRIPTION
Euros is the correct plural form of Euro and not Euroes.